### PR TITLE
feat: add support for dark rooms and torchlight

### DIFF
--- a/Dragon-dangeon.xcodeproj/project.pbxproj
+++ b/Dragon-dangeon.xcodeproj/project.pbxproj
@@ -24,6 +24,7 @@
 		CE27AC252E1036E000FECF74 /* CommandParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE27AC242E1036E000FECF74 /* CommandParser.swift */; };
 		CE27AC292E11B00B00FECF74 /* MazeValidator.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE27AC282E11B00B00FECF74 /* MazeValidator.swift */; };
 		CE27AC2D2E1271A200FECF74 /* MobEncounterHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE27AC2C2E1271A200FECF74 /* MobEncounterHandler.swift */; };
+		CE27AC2F2E13123D00FECF74 /* Torchlight.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE27AC2E2E13123D00FECF74 /* Torchlight.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXCopyFilesBuildPhase section */
@@ -57,6 +58,7 @@
 		CE27AC242E1036E000FECF74 /* CommandParser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommandParser.swift; sourceTree = "<group>"; };
 		CE27AC282E11B00B00FECF74 /* MazeValidator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MazeValidator.swift; sourceTree = "<group>"; };
 		CE27AC2C2E1271A200FECF74 /* MobEncounterHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MobEncounterHandler.swift; sourceTree = "<group>"; };
+		CE27AC2E2E13123D00FECF74 /* Torchlight.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Torchlight.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -128,6 +130,7 @@
 				CE27AC132E102A5C00FECF74 /* Food.swift */,
 				CE27AC152E102ABD00FECF74 /* Sword.swift */,
 				CE27AC172E102AF300FECF74 /* Gold.swift */,
+				CE27AC2E2E13123D00FECF74 /* Torchlight.swift */,
 			);
 			path = Items;
 			sourceTree = "<group>";
@@ -222,6 +225,7 @@
 				CE27AC1C2E1032E400FECF74 /* Player.swift in Sources */,
 				CE27AC292E11B00B00FECF74 /* MazeValidator.swift in Sources */,
 				CE27AC252E1036E000FECF74 /* CommandParser.swift in Sources */,
+				CE27AC2F2E13123D00FECF74 /* Torchlight.swift in Sources */,
 				CE27AC2D2E1271A200FECF74 /* MobEncounterHandler.swift in Sources */,
 				CE27AC212E10365200FECF74 /* GameEngine.swift in Sources */,
 				CE27AC182E102AF300FECF74 /* Gold.swift in Sources */,

--- a/Dragon-dangeon/Engine/Command.swift
+++ b/Dragon-dangeon/Engine/Command.swift
@@ -1,7 +1,7 @@
 
 import Foundation
 
-enum Command {
+enum Command: Equatable {
     case move(Direction)
     case get(String)
     case drop(String)

--- a/Dragon-dangeon/Entities/Item.swift
+++ b/Dragon-dangeon/Entities/Item.swift
@@ -1,9 +1,3 @@
-//
-//  Item.swift
-//  DragonsGame
-//
-//  Created by Baytik  on 28/6/25.
-//
 
 import Foundation
 

--- a/Dragon-dangeon/Entities/Items/Torchlight.swift
+++ b/Dragon-dangeon/Entities/Items/Torchlight.swift
@@ -1,0 +1,6 @@
+final class Torchlight: Item {
+    var name: String { "torchlight" }
+    var isCollectible: Bool { true }
+    var description: String { "torchlight" }
+}
+

--- a/Dragon-dangeon/Entities/Maze.swift
+++ b/Dragon-dangeon/Entities/Maze.swift
@@ -82,11 +82,12 @@ final class Maze {
                 room.addItem(Gold(coins: Int.random(in: 50...200)))
             case 90..<95:
                 room.isDark = true
+            case 95..<98:
+                room.addItem(Torchlight())
             default:
                 break
             }
 
-            // Дополнительно с шансом 5% — монстр
             if Int.random(in: 0..<100) < 5 {
                 room.monsterName = ["goblin", "orc", "skeleton", "demon"].randomElement()
                 print("💀 Monster spawned at [\(pos.x), \(pos.y)] — \(room.monsterName!)")


### PR DESCRIPTION
## ✨ Что сделано

- Добавлена генерация тёмных комнат (isDark)
- Реализована логика фонаря (torchlight):
  - при наличии в инвентаре комната освещается
  - если выбросить фонарь — комната остаётся освещённой
- Ограничены действия игрока в тёмной комнате
  - Разрешены только команды движения и `help`
  - Нельзя брать/использовать предметы в темноте без фонаря

## ✅ Проверено

- [x] Комнаты с `isDark` описываются как тёмные
- [x] `torchlight` позволяет видеть и действовать
- [x] После drop факела — свет сохраняется

## 📌 Issue

Closes #3
