### PR TITLE
feat: implement gold pickup and tracking

### DIFF
--- a/Dragon-dangeon/Entities/Items/Gold.swift
+++ b/Dragon-dangeon/Entities/Items/Gold.swift
@@ -9,7 +9,7 @@ final class Gold: Item {
     }
     
     var name : String {
-        return "gold (\(coins) coins"
+        return "gold (\(coins) coins)"
     }
     
     var isCollectible: Bool { true }


### PR DESCRIPTION
## ✨ Что сделано

- Добавлен предмет `Gold(coins: Int)`
- Генерируется в комнатах с шансом
- Отображается как `gold (120 coins)`
- При `get gold` — монеты прибавляются к счётчику, предмет удаляется
- `Gold` не попадает в инвентарь

## 📌 Issue

Closes #4
